### PR TITLE
Use `preexec_func` always

### DIFF
--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -63,7 +63,7 @@ class SSHSocket(socket.socket):
             shell=True,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
-            preexec_fn=None if constants.IS_WINDOWS_PLATFORM else preexec_func)
+            preexec_fn=preexec_func)
 
     def _write(self, data):
         if not self.proc or self.proc.stdin.closed:


### PR DESCRIPTION
`preexec_func` is still None if it is win32

Signed-off-by: q0w <43147888+q0w@users.noreply.github.com>